### PR TITLE
Update entropy.c to remove warning.

### DIFF
--- a/extras/entropy.c
+++ b/extras/entropy.c
@@ -74,7 +74,7 @@ bool entropy_getbytes(void* dest, size_t size)
     int fd = open("/dev/random", O_RDONLY);
     if (fd < 0)
         return false;
-    int sz = read(fd, dest, size);
+    size_t sz = read(fd, dest, size);
     if (sz < size)
         return false;
     return close(fd) == 0;


### PR DESCRIPTION
Use size_t for comparison so it is comparing like types.